### PR TITLE
Support php 7.2

### DIFF
--- a/src/Model/PolicyRuleAttribute.php
+++ b/src/Model/PolicyRuleAttribute.php
@@ -4,7 +4,7 @@ namespace PhpAbac\Model;
 
 class PolicyRuleAttribute
 {
-    /** @var PhpAbac\Model\AbstractAttribute **/
+    /** @var \PhpAbac\Model\AbstractAttribute **/
     protected $attribute;
     /** @var string **/
     protected $comparisonType;
@@ -13,7 +13,7 @@ class PolicyRuleAttribute
     /** @var mixed **/
     protected $value;
     /** @var array **/
-    protected $extraData;
+    protected $extraData = [];
     /** @var array Extended parameter */
     protected $getter_params_a = [];
 


### PR DESCRIPTION
There're 2 places, that called to PolicyRuleAttribute::getExtraData(), then count/foreach it. 

But somehow if extra data is not setted, we will get error. In php7.0 we can count(null) but in php7.2 we can not.

This bugfix is works with php7.2. 

Please consider to merge it. Thank you.