### PR TITLE
Move CS fixer to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "php": ">=7.0",
         "psr/cache": "~1.0",
         "symfony/config": "~3.0|^4.0",
-	  	"symfony/yaml" : "~3.0|^4.0",
-        "friendsofphp/php-cs-fixer": "^2.12"
+        "symfony/yaml" : "~3.0|^4.0"
     },
     "support": {
         "email": "kern046@gmail.com"
@@ -30,6 +29,7 @@
         }
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.12",
         "phpunit/phpunit": "^6.5"
     }
 }


### PR DESCRIPTION
There is no need to have code style fixer in production environment.
Additionally replaced tabs with spaces.